### PR TITLE
Fix version name

### DIFF
--- a/multi-monitor-panel@coolssor/metadata.json
+++ b/multi-monitor-panel@coolssor/metadata.json
@@ -6,5 +6,5 @@
     "gettext-domain": "multi-monitor-panel",
     "description": "Show the GNOME top panel on all monitors",
     "url": "https://github.com/coolssor/multi-monitor-panel",
-    "version-name": 1.2
+    "version-name": "v1.2"
 }


### PR DESCRIPTION
Updated to string instead of float

Now also matches release name in GitHub