### PR TITLE
Add GNOME 49 support

### DIFF
--- a/multi-monitor-panel@coolssor/metadata.json
+++ b/multi-monitor-panel@coolssor/metadata.json
@@ -3,7 +3,8 @@
         "45",
         "46",
         "47",
-        "48"
+        "48",
+        "49"
     ],
     "uuid": "multi-monitor-panel@coolssor",
     "name": "Multi-monitor panel",
@@ -11,5 +12,5 @@
     "gettext-domain": "multi-monitor-panel",
     "description": "Show the GNOME top panel on all monitors",
     "url": "https://github.com/coolssor/multi-monitor-panel",
-    "version-name": "v1.2"
+    "version-name": "v1.3"
 }


### PR DESCRIPTION
Add "49" to the shell versions listed in the extension metadata

Resolves #16 